### PR TITLE
Add support for deterministic builds and fix coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,5 +109,6 @@ jobs:
       if: always()
       uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: ./output/TestResults/Coverage.xml
         flags: ${{ matrix.info.name }}

--- a/build.ps1
+++ b/build.ps1
@@ -44,7 +44,6 @@ Write-Host "Installing PowerShell dependencies" -ForegroundColor Cyan
 $deps = $Task -eq 'Build' ? $Manifest.BuildRequirements : $Manifest.TestRequirements
 $deps | Install-BuildDependencies
 
-
 # This is a special step to setup test dependencies
 Write-Host "Compiling test Forge module" -ForegroundColor Cyan
 

--- a/src/RemoteForge/RemoteForge.csproj
+++ b/src/RemoteForge/RemoteForge.csproj
@@ -5,7 +5,16 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="7.3.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
   </ItemGroup>
 </Project>

--- a/tests/TestForge/TestForge.csproj
+++ b/tests/TestForge/TestForge.csproj
@@ -4,8 +4,17 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="7.3.0" PrivateAssets="all" />
     <ProjectReference Include="../../src/RemoteForge/RemoteForge.csproj" SpecificVersion="false" Private="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all"/>
   </ItemGroup>
 </Project>

--- a/tools/InvokeBuild.ps1
+++ b/tools/InvokeBuild.ps1
@@ -192,6 +192,7 @@ task PesterTests {
     $watchFolder = [Path]::Combine($Manifest.ReleasePath, 'bin', $Manifest.TestFramework)
     $unitCoveragePath = [Path]::Combine($Manifest.TestResultsPath, "UnitCoverage.json")
     $coveragePath = [Path]::Combine($Manifest.TestResultsPath, "Coverage.xml")
+    $sourceMappingFile = [Path]::Combine($Manifest.TestResultsPath, "CoverageSourceMapping.txt")
 
     $arguments = @(
         $watchFolder
@@ -202,6 +203,10 @@ task PesterTests {
         '--verbosity', 'minimal'
         if (Test-Path -LiteralPath $unitCoveragePath) {
             '--merge-with', $unitCoveragePath
+        }
+        if ($env:GITHUB_ACTIONS -eq 'true') {
+            Set-Content $sourceMappingFile "|$($Manifest.RepositoryPath)$([Path]::DirectorySeparatorChar)=/_/"
+            '--source-mapping-file', $sourceMappingFile
         }
     )
     $origEnv = $env:PSModulePath

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -14,6 +14,7 @@ class Manifest {
     [ValidateSet("Debug", "Release")]
     [string]$Configuration
 
+    [string]$RepositoryPath
     [string]$DocsPath
     [string]$DotnetPath
     [string]$OutputPath
@@ -36,8 +37,9 @@ class Manifest {
         [Architecture]$PowerShellArch,
         [string]$ManifestPath
     ) {
+        $this.RepositoryPath = [Path]::GetFullPath([Path]::Combine($PSScriptRoot, ".."))
         $moduleManifestParams = @{
-            Path = [Path]::Combine($PSScriptRoot, "..", "module", "*.psd1")
+            Path = [Path]::Combine($this.RepositoryPath, "module", "*.psd1")
             # Can emit errors about invalid RootModule which don't matter here
             ErrorAction = 'Ignore'
             WarningAction = 'Ignore'
@@ -49,20 +51,13 @@ class Manifest {
         $raw = Import-PowerShellDataFile -LiteralPath $ManifestPath
         $this.DotnetProject = $raw.DotnetProject ?? $this.Module.Name
 
-        $this.DocsPath = [Path]::GetFullPath(
-            [Path]::Combine($PSScriptRoot, "..", "docs"))
-        $this.DotnetPath = [Path]::GetFullPath(
-            [Path]::Combine($PSScriptRoot, "..", "src", $this.DotnetProject))
-        $this.OutputPath = [Path]::GetFullPath(
-            [Path]::Combine($PSScriptRoot, "..", "output"))
-        $this.PowerShellPath = [Path]::GetFullPath(
-            [Path]::Combine($PSScriptRoot, "..", "module"))
-        $this.ReleasePath = [Path]::GetFullPath(
-            [Path]::Combine($this.OutputPath, $this.Module.Name, $this.Module.Version))
-        $this.TestPath = [Path]::GetFullPath(
-            [Path]::Combine($PSScriptRoot, "..", "tests"))
-        $this.TestResultsPath = [Path]::GetFullPath(
-            [Path]::Combine($this.OutputPath, "TestResults"))
+        $this.DocsPath = [Path]::Combine($this.RepositoryPath, "docs")
+        $this.DotnetPath = [Path]::Combine($this.RepositoryPath, "src", $this.DotnetProject)
+        $this.OutputPath = [Path]::Combine($this.RepositoryPath, "output")
+        $this.PowerShellPath = [Path]::Combine($this.RepositoryPath, "module")
+        $this.ReleasePath = [Path]::Combine($this.OutputPath, $this.Module.Name, $this.Module.Version)
+        $this.TestPath = [Path]::Combine($this.RepositoryPath, "tests")
+        $this.TestResultsPath = [Path]::Combine($this.OutputPath, "TestResults")
 
         if (-not (Test-Path -LiteralPath $this.ReleasePath)) {
             New-Item -Path $this.ReleasePath -ItemType Directory -Force | Out-Null


### PR DESCRIPTION
Uses deterministic builds in CI and a new feature in coverlet allowing us to map our repo to the SourceLink assembly to correctly collect coverage regardless of where it is built from.