### PR TITLE
Use Runspace scoped registrations

### DIFF
--- a/src/RemoteForge/Commands/RemoteForgeCommand.cs
+++ b/src/RemoteForge/Commands/RemoteForgeCommand.cs
@@ -31,7 +31,7 @@ public sealed class GetRemoteForgeCommand : PSCmdlet
 
     protected override void EndProcessing()
     {
-        foreach (RemoteForgeRegistration forge in RemoteForgeRegistration.Registrations.ToArray())
+        foreach (RemoteForgeRegistration forge in RegistrationStorage.GetFromTLS().Registrations.ToArray())
         {
             WriteVerbose($"Checking for forge '{forge.Name}' matches requested Name");
 

--- a/src/RemoteForge/OnImportAndRemove.cs
+++ b/src/RemoteForge/OnImportAndRemove.cs
@@ -20,7 +20,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
 
     public void OnRemove(PSModuleInfo module)
     {
-        RemoteForgeRegistration.Registrations.Clear();
+        RegistrationStorage.GetFromTLS().Registrations.Clear();
     }
 
     private static SSHConnectionInfo CreateSshConnectionInfo(string info)

--- a/tests/units/RemoteForgeRegistrationTests.cs
+++ b/tests/units/RemoteForgeRegistrationTests.cs
@@ -11,6 +11,8 @@ public class RemoteForgeRegistrationTests : IDisposable
 
     public RemoteForgeRegistrationTests() : base()
     {
+        Runspace.DefaultRunspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault2());
+        Runspace.DefaultRunspace.Open();
         _remoteForgeModule.OnImport();
     }
 
@@ -94,5 +96,6 @@ public class RemoteForgeRegistrationTests : IDisposable
     public void Dispose()
     {
         _remoteForgeModule.OnRemove(null!);
+        Runspace.DefaultRunspace?.Dispose();
     }
 }

--- a/tests/units/StringForgeConnectionInfoPSSessionTests.cs
+++ b/tests/units/StringForgeConnectionInfoPSSessionTests.cs
@@ -37,6 +37,8 @@ public class StringForgeConnectionInfoPSSessionTests : IDisposable
 
     public StringForgeConnectionInfoPSSessionTests() : base()
     {
+        Runspace.DefaultRunspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault2());
+        Runspace.DefaultRunspace.Open();
         _remoteForgeModule.OnImport();
     }
 
@@ -115,5 +117,6 @@ public class StringForgeConnectionInfoPSSessionTests : IDisposable
     public void Dispose()
     {
         _remoteForgeModule.OnRemove(null!);
+        Runspace.DefaultRunspace?.Dispose();
     }
 }


### PR DESCRIPTION
Move away from thread local storage for registrations to a new method that scopes the storage to a Runspace. This is because a Runspace where a module is loaded is not guaranteed to always run on the same thread breaking the previously registered forges.